### PR TITLE
Initialize lock module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["eslint-config-mm"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,6 @@
+check:
+  global:
+    statements: 100
+    lines: 100
+    branches: 100
+    functions: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+ sudo: false
+
+ language: node_js
+ node_js: "4.2"
+ 
+ after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Enrise node-lock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,24 @@ Retrieve a list of all current locks. Callback will be called with parameters `[
 
 #### `lock.delete(callback: function)`
 Delete the entire lock-index. Callback will be called with parameter `[err]`.
+
+### Example
+```js
+const lock = new require('enrise-lock')({
+  esClient: new require('elasticsearch').Client(),
+  index: 'globallock',
+  type: 'lockdocument'
+});
+
+// Set lock
+lock.acquire('my-resource', 'owner', (err, success) => {
+  // Do some asynchronous operation
+  // ...
+
+  // Release lock
+  lock.release('my-resource', 'owner', (err, success) => {
+  	// ...
+  });
+});
+
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # Node.js lock module
+
+[![build:?](https://img.shields.io/travis/Enrise/node-lock.svg?style=flat-square)](https://travis-ci.org/Enrise/node-lock)
+[![Coverage Status](https://img.shields.io/coveralls/Enrise/node-lock/master.svg?style=flat-square)](https://coveralls.io/github/Enrise/node-lock?branch=master)
+[![dependencies:?](https://img.shields.io/david/Enrise/node-lock.svg?style=flat-square)](https://david-dm.org/Enrise/node-lock)
+[![devDependencies:?](https://img.shields.io/david/dev/Enrise/node-lock.svg?style=flat-square)](https://david-dm.org/Enrise/node-lock)
+
+> An elasticsearch based lock mechanism.
+
+### Installation
+NPM: `npm install enrise-lock --save`  
+Yarn: `yarn add enrise-lock`
+
+### Initialization
+Require and instantiate the locker.
+`const lock = new require('enrise-lock')(config: Object);`
+
+Where `config` is an object with three required options.
+
+- `esClient: elasticsearch`: An elasticsearch client for the lock module to use. This can either be an [elasticsearch](https://www.npmjs.com/package/elasticsearch) or an [enrise-esclient](https://www.npmjs.com/package/enrise-esclient) instance.
+- `index: String`: The elasticsearch index that will be used to store all lock-documents.
+- `type: String`: The index-type that will be used to store all lock-documents.
+
+### Usage and API methods
+
+#### `lock.acquire(resource: String, owner: String, callback: function)`
+Set a lock for resource: `resource` and owner: `owner`. Callback will be called with parameters `[err, success: boolean]`.
+
+#### `lock.release(resource: String, owner: String, callback: function)`
+Release a lock for resource: `resource` and owner: `owner`. Callback will be called with parameter `[err]`.
+
+#### `lock.isLocked(resource: String, callback: function)`
+Check if a resource is locked. Callback will be called with parameters `[err, isLocked: boolean]`.
+
+#### `lock.list(callback: function)`
+Retrieve a list of all current locks. Callback will be called with parameters `[err, locks: Object]`. Where the key in locks represents the resource and the value an object with the owner.
+
+#### `lock.delete(callback: function)`
+Delete the entire lock-index. Callback will be called with parameter `[err]`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 [![dependencies:?](https://img.shields.io/david/Enrise/node-lock.svg?style=flat-square)](https://david-dm.org/Enrise/node-lock)
 [![devDependencies:?](https://img.shields.io/david/dev/Enrise/node-lock.svg?style=flat-square)](https://david-dm.org/Enrise/node-lock)
 
-> An elasticsearch based lock mechanism.
+> An elasticsearch based lock mechanism for resources and ownership.
+
+### Introduction
+This module provides abstraction methods to lock a resource with an owner. The owner is the name of the process requesting a lock. The resource would be the specific element/index/endpoint/etc.. that requires locking.
 
 ### Installation
 NPM: `npm install enrise-lock --save`  
@@ -15,19 +18,20 @@ Yarn: `yarn add enrise-lock`
 Require and instantiate the locker.
 `const lock = new require('enrise-lock')(config: Object);`
 
-Where `config` is an object with three required options.
+Where `config` is an object with the following options. Type is optional, the rest is mandatory.
 
 - `esClient: elasticsearch`: An elasticsearch client for the lock module to use. This can either be an [elasticsearch](https://www.npmjs.com/package/elasticsearch) or an [enrise-esclient](https://www.npmjs.com/package/enrise-esclient) instance.
 - `index: String`: The elasticsearch index that will be used to store all lock-documents.
-- `type: String`: The index-type that will be used to store all lock-documents.
+- `owner: String`: The name of the process that is looking to place the lock.
+- `[type: String]`: The index-type that will be used to store all lock-documents. This will default to `'lockdocument'`.
 
 ### Usage and API methods
 
-#### `lock.acquire(resource: String, owner: String, callback: function)`
-Set a lock for resource: `resource` and owner: `owner`. Callback will be called with parameters `[err, success: boolean]`.
+#### `lock.acquire(resource: String, callback: function)`
+Set a lock for resource: `resource`. Callback will be called with parameters `[err, success: boolean]`. The success paramater will be false if a lock already exists.
 
-#### `lock.release(resource: String, owner: String, callback: function)`
-Release a lock for resource: `resource` and owner: `owner`. Callback will be called with parameter `[err]`.
+#### `lock.release(resource: String, callback: function)`
+Release a lock for resource: `resource`. Callback will be called with parameter `[err]`.
 
 #### `lock.isLocked(resource: String, callback: function)`
 Check if a resource is locked. Callback will be called with parameters `[err, isLocked: boolean]`.
@@ -43,16 +47,17 @@ Delete the entire lock-index. Callback will be called with parameter `[err]`.
 const lock = new require('enrise-lock')({
   esClient: new require('elasticsearch').Client(),
   index: 'globallock',
-  type: 'lockdocument'
+  type: 'lockdocument',
+  owner: 'api'
 });
 
 // Set lock
-lock.acquire('my-resource', 'owner', (err, success) => {
+lock.acquire('my-resource', (err, success) => {
   // Do some asynchronous operation
   // ...
 
   // Release lock
-  lock.release('my-resource', 'owner', (err, success) => {
+  lock.release('my-resource', (err, success) => {
   	// ...
   });
 });

--- a/index.js
+++ b/index.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const _ = require('lodash');
+
+// verifyParameters just verifies the three provided parameters so the callback will only be inspected, not used
+function verifyParameters(resource, owner, cb) {
+
+  // Callback might be one of the incorrect parameters, so can't use the callback
+  if (!(_.isString(resource) && _.isString(owner) && _.isFunction(cb) && resource.length && owner.length && cb)) {
+    throw new Error('Incorrect parameter(s)');
+  }
+}
+
+class Lock {
+  constructor(settings) {
+    this.esClient = settings.esClient;
+    this.index = settings.index;
+    this.type = settings.type;
+  }
+
+  acquire(resource, owner, cb) {
+    verifyParameters(resource, owner, cb);
+    this._acquireLock({
+      resource: resource,
+      owner: owner
+    }, cb);
+  }
+
+  release(resource, owner, cb) {
+    verifyParameters(resource, owner, cb);
+    this._releaseLock({
+      resource: resource,
+      owner: owner
+    }, cb);
+  }
+
+  isLocked(resource, cb) {
+    this.esClient.get({
+      index: this.index,
+      type: this.type,
+      id: resource
+    }, (lockErr, lockRes, statusCode) => {
+      if (statusCode === 404) {
+        return cb(null, false);
+      }
+
+      cb(lockErr, true, _.get(lockRes, '_source.owner'));
+    });
+  }
+
+  list(cb) {
+    this.esClient.search({
+      index: this.index,
+      type: this.type
+    }, (lockErr, locksRes, statusCode) => {
+      if (statusCode === 404) {
+        return cb(null, false);
+      }
+
+      cb(lockErr, _.reduce(_.get(locksRes, 'hits.hits'), (locks, lockDocument) => {
+        locks[lockDocument._id] = lockDocument._source;
+        return locks;
+      }, {}));
+    });
+  }
+
+  delete(cb) {
+    this.esClient.indices.delete({
+      index: this.index
+    }, (deleteError) => {
+      cb(deleteError);
+    });
+  }
+
+  // 'Private' methods
+  _acquireLock(req, cb) {
+    const lockDocument = {
+      body: _.omit(req, 'resource'),
+      index: this.index,
+      type: this.type,
+      id: req.resource,
+      refresh: true
+    };
+
+    this.esClient.create(lockDocument, (err, res) => {
+      // Lock (document) already exists
+      if (err && err.status === 409) {
+        return cb(null, false);
+      }
+
+      cb(err, res && res.created);
+    });
+  }
+
+  _releaseLock(req, cb) {
+    this.esClient.delete({
+      index: this.index,
+      type: this.type,
+      id: req.resource,
+      refresh: true
+    }, (deleteError, response) => {
+      cb(deleteError || (response.found ? null : new Error('Missing lockdocument for request', req)));
+    });
+  }
+}
+
+module.exports = Lock;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "enrise-lock",
+  "description": "Lock functionality used within Enrise projects and module's",
+  "version": "0.1.0",
+  "author": "Team MatchMinds @ Enrise",
+  "main": "index.js",
+  "license": "MIT",
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "scripts": {
+    "lint": "eslint index.js test",
+    "unittest": "mocha test/*.spec.js",
+    "cover": "istanbul cover _mocha -- -R spec test/*.spec.js; istanbul check-coverage",
+    "test": "npm run lint && npm run cover"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Enrise/node-lock"
+  },
+  "bugs": {
+    "url": "https://github.com/Enrise/node-lock/issues"
+  },
+  "dependencies": {
+    "lodash": "^4.16.4"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "coveralls": "^2.11.14",
+    "eslint": "^3.8.1",
+    "eslint-config-mm": "^1.1.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.1.2",
+    "sinon": "^1.17.6",
+    "sinon-chai": "^2.8.0"
+  }
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "no-unused-expressions": 0
+  }
+}

--- a/test/lock.spec.js
+++ b/test/lock.spec.js
@@ -1,0 +1,288 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+describe('Lock', () => {
+  const esClientStub = {};
+  const Lock = require('../index.js');
+  const lock = new Lock({
+    esClient: esClientStub,
+    index: 'lock-index',
+    type: 'lock-type'
+  });
+
+  beforeEach(() => {
+    esClientStub.create = sinon.stub();
+    esClientStub.create.callsArgWith(1, null, {created: true});
+    esClientStub.delete = sinon.stub();
+    esClientStub.delete.callsArgWith(1, null, {found: true});
+  });
+
+  it('initializes correctly', () => {
+    expect(Lock).to.be.a.function;
+  });
+
+  describe('acquire and release functionality', () => {
+    it('returns true when a lock for a resource is requested', (done) => {
+      lock.acquire('testresource', 'unittest', (err, result) => {
+        expect(result).to.be.true;
+        expect(esClientStub.create).to.have.been.calledOnce;
+        expect(esClientStub.create).to.have.been.calledWith({
+          body: {
+            owner: 'unittest'
+          },
+          index: 'lock-index',
+          type: 'lock-type',
+          id: 'testresource',
+          refresh: true
+        });
+        expect(esClientStub.delete).to.not.have.been.called;
+        done(err);
+      });
+    });
+
+    it('succesfully acquires and releases a lock for a resource', (done) => {
+      lock.acquire('testresource', 'unittest', (acquireError, result) => {
+        expect(result).to.be.true;
+        expect(esClientStub.create).to.have.been.calledOnce;
+        expect(esClientStub.create).to.have.been.calledWithMatch({body: {owner: 'unittest'}, id: 'testresource'});
+        expect(esClientStub.delete).to.not.have.been.called;
+        lock.release('testresource', 'unittest', (releaseError) => {
+          expect(esClientStub.create).to.have.been.calledOnce;
+          expect(esClientStub.delete).to.have.been.calledOnce;
+          expect(esClientStub.delete).to.have.been.calledWith({
+            index: 'lock-index',
+            type: 'lock-type',
+            id: 'testresource',
+            refresh: true
+          });
+          done(acquireError || releaseError);
+        });
+      });
+    });
+
+    it('succesfully acquires and releases locks for different resources in incorrect order', (done) => {
+      lock.acquire('testresource1', 'unittest', (acquireError1, result1) => {
+        expect(result1).to.be.true;
+        expect(esClientStub.create).to.have.been.calledOnce;
+        expect(esClientStub.create).to.have.been.calledWithMatch({body: {owner: 'unittest'}, id: 'testresource1'});
+        expect(esClientStub.delete).to.not.have.been.called;
+        lock.acquire('testresource2', 'unittest', (acquireError2, result2) => {
+          expect(result2).to.be.true;
+          expect(esClientStub.create).to.have.been.calledTwice;
+          expect(esClientStub.create).to.have.been.calledWithMatch({body: {owner: 'unittest'}, id: 'testresource2'});
+          expect(esClientStub.delete).to.not.have.been.called;
+          lock.release('testresource1', 'unittest', (releaseError1) => {
+            expect(esClientStub.create).to.have.been.calledTwice;
+            expect(esClientStub.delete).to.have.been.calledOnce;
+            expect(esClientStub.delete).to.have.been.calledWithMatch({id: 'testresource1'});
+            lock.release('testresource2', 'unittest', (releaseError2) => {
+              expect(esClientStub.create).to.have.been.calledTwice;
+              expect(esClientStub.delete).to.have.been.calledTwice;
+              expect(esClientStub.delete).to.have.been.calledWithMatch({id: 'testresource2'});
+              done(acquireError1 || acquireError2 || releaseError1 || releaseError2);
+            });
+          });
+        });
+      });
+    });
+
+    it('fails to acquire a second lock on a resource', (done) => {
+      lock.acquire('testresource', 'unittest', (acquireError1, result1) => {
+        expect(result1).to.be.true;
+        expect(esClientStub.create).to.have.been.calledOnce;
+        expect(esClientStub.create).to.have.been.calledWithMatch({body: {owner: 'unittest'}, id: 'testresource'});
+        expect(esClientStub.delete).to.not.have.been.called;
+
+        esClientStub.create.onCall(1).callsArgWith(1, {status: 409});
+        lock.acquire('testresource', 'unittest', (acquireError2, result2) => {
+          expect(result2).to.be.false;
+          expect(esClientStub.create).to.have.been.calledTwice;
+          expect(esClientStub.delete).to.not.have.been.called;
+          done(acquireError1 || acquireError2);
+        });
+      });
+    });
+
+    it('throws an error when a parameter is missing when acquiring a lock', (done) => {
+      expect(() => {lock.acquire('justone', () => {});}).to.throw(Error);
+      done();
+    });
+
+    it('returns false when there is no lock to release', (done) => {
+      esClientStub.delete = sinon.stub();
+      esClientStub.delete.callsArgWith(1, null, {found: false});
+      lock.release('testresource', 'unittest', (error, result) => {
+        expect(result).to.be.undefined;
+        expect(error).to.be.an('Error');
+        expect(esClientStub.delete).to.have.been.calledOnce;
+        expect(esClientStub.delete).to.have.been.calledWithMatch({id: 'testresource'});
+        expect(esClientStub.create).to.not.have.been.called;
+        done();
+      });
+    });
+    it('returns false when resource about to acquire is already locked', (done) => {
+      esClientStub.create = sinon.stub();
+      esClientStub.create.callsArgWith(1, {status: 409});
+      lock.acquire('testresource', 'unittest', (error) => {
+        expect(esClientStub.create).to.have.been.calledOnce;
+        expect(esClientStub.create).to.have.been.calledWithMatch({id: 'testresource'});
+        expect(esClientStub.delete).to.not.have.been.called;
+        done(error);
+      });
+    });
+    it('passes on Elasticsearch-error', (done) => {
+      esClientStub.create = sinon.stub();
+      esClientStub.create.callsArgWith(1, new Error('testCreate'));
+      esClientStub.delete = sinon.stub();
+      esClientStub.delete.callsArgWith(1, new Error('testDelete'));
+      lock.acquire('testresource', 'unittest', (acquireError, acquireResult) => {
+        expect(acquireError).to.be.an('Error');
+        expect(acquireResult).to.be.undefined;
+        lock.release('testresource', 'unittest', (releaseError) => {
+          expect(releaseError).to.be.an('Error');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('status functionality', () => {
+    it('correctly reports a resource as available when no lock exists', (done) => {
+      esClientStub.get = sinon.stub();
+      esClientStub.get.callsArgWith(1, new Error('Not Found'), null, 404);
+      lock.isLocked('testresource', (lockError, locked) => {
+        expect(esClientStub.get).to.have.been.calledOnce;
+        expect(esClientStub.get).to.have.been.calledWithMatch({
+          index: 'lock-index',
+          type: 'lock-type',
+          id: 'testresource'
+        });
+        expect(locked).to.be.false;
+        done(lockError);
+      });
+    });
+    it('correctly reports a resource as unavailable with the owner when a lock exists', (done) => {
+      esClientStub.get = sinon.stub();
+      esClientStub.get.callsArgWith(1, null, {
+        _source: {
+          owner: 'unittest'
+        }
+      }, 202);
+      lock.isLocked('testresource', (lockError, locked, owner) => {
+        expect(esClientStub.get).to.have.been.calledOnce;
+        expect(esClientStub.get).to.have.been.calledWithMatch({id: 'testresource'});
+        expect(locked).to.be.true;
+        expect(owner).to.equal('unittest');
+        done(lockError);
+      });
+    });
+    it('passes on ES errors', (done) => {
+      esClientStub.get = sinon.stub();
+      esClientStub.get.callsArgWith(1, new Error('Timeout'), null, 408);
+      lock.isLocked('testresource', (lockError, locked) => {
+        expect(esClientStub.get).to.have.been.calledOnce;
+        expect(esClientStub.get).to.have.been.calledWithMatch({id: 'testresource'});
+        expect(locked).to.be.true;
+        expect(lockError).to.exists;
+        done();
+      });
+    });
+
+    it('correctly lists no locks when no documents are available', (done) => {
+      esClientStub.search = sinon.stub();
+      esClientStub.search.callsArgWith(1, null, {
+        hits: {
+          hits: []
+        }
+      }, 408);
+      lock.list((lockError, locks) => {
+        expect(esClientStub.search).to.have.been.calledOnce;
+        expect(esClientStub.search).to.have.been.calledWith({
+          index: 'lock-index',
+          type: 'lock-type'
+        });
+        expect(locks).to.deep.equal({});
+        done(lockError);
+      });
+    });
+    it('passes on ES errors', (done) => {
+      esClientStub.search = sinon.stub();
+      esClientStub.search.callsArgWith(1, new Error('Timeout'), null, 408);
+      lock.list((lockError) => {
+        expect(esClientStub.search).to.have.been.calledOnce;
+        expect(lockError).to.exists;
+        done();
+      });
+    });
+    it('correctly transforms lock documents into a lock object', (done) => {
+      esClientStub.search = sinon.stub();
+      const searchResponse = {
+        hits: {
+          hits: [
+            {
+              _id: 'testresource1',
+              _source: {
+                owner: 'unittestA'
+              }
+            },
+            {
+              _id: 'testresource2',
+              _source: {
+                owner: 'unittestB'
+              }
+            }
+          ]
+        }
+      };
+      esClientStub.search.callsArgWith(1, null, searchResponse);
+      lock.list((lockError, locks) => {
+        expect(esClientStub.search).to.have.been.calledOnce;
+        expect(locks).to.deep.equal({
+          testresource1: {
+            owner: 'unittestA'
+          },
+          testresource2: {
+            owner: 'unittestB'
+          }
+        });
+        done(lockError);
+      });
+    });
+    it('finishes with false when nothing is found', (done) => {
+      esClientStub.search = sinon.stub();
+      esClientStub.search.callsArgWith(1, null, null, 404);
+      lock.list((lockError, locks) => {
+        expect(locks).to.equal(false);
+        done(lockError);
+      });
+    });
+  });
+  describe('delete lock index functionality', () => {
+    it('makes a delete call on the lock index', (done) => {
+      esClientStub.indices = sinon.stub();
+      esClientStub.indices.delete = sinon.stub();
+      esClientStub.indices.delete.callsArgWith(1, null, {acknowledged: true});
+
+      lock.delete((deleteError) => {
+        expect(esClientStub.indices.delete).to.have.been.calledOnce;
+        expect(esClientStub.indices.delete).to.have.been.calledWith({index: 'lock-index'});
+        done(deleteError);
+      });
+    });
+    it('passes on Elasticsearch-error', (done) => {
+      esClientStub.indices = sinon.stub();
+      esClientStub.indices.delete = sinon.stub();
+      esClientStub.indices.delete.callsArgWith(1, new Error('Timeout'));
+
+      lock.delete((deleteError) => {
+        expect(esClientStub.indices.delete).to.have.been.calledOnce;
+        expect(deleteError).to.exists;
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Context
Create the initial lock module abstracted from our current projects.

### What has been done
- Added the enrise-lock mechanism, code, README docs, travis, tests, package.json, LICENSE, eslint, test-coverage, Travis and .gitignore

### How to test
- Run `npm run test`, all tests pass with 100% test coverage

### Notes
- The buttons in the README will start working after the merge to master