### PR TITLE
Enable module to instantiate without keyword new

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,98 +12,100 @@ function verifyParameters(resource, cb) {
   }
 }
 
-class Lock {
-  constructor(settings) {
-    if (!_.isString(settings.owner) || !settings.owner) {
-      throw new Error('Owner must a string');
+function Lock(settings) {
+  if (!(this instanceof Lock)) {
+    return new Lock(settings);
+  }
+
+  if (!_.isString(settings.owner) || !settings.owner) {
+    throw new Error('Owner must a string');
+  }
+
+  this.esClient = settings.esClient;
+  this.index = settings.index;
+  this.type = settings.type || defaultType;
+  this.owner = settings.owner;
+}
+
+Lock.prototype.acquire = function (resource, cb) {
+  verifyParameters(resource, cb);
+  this._acquireLock(resource, cb);
+};
+
+Lock.prototype.release = function (resource, cb) {
+  verifyParameters(resource, cb);
+  this._releaseLock(resource, cb);
+};
+
+Lock.prototype.isLocked = function (resource, cb) {
+  this.esClient.get({
+    index: this.index,
+    type: this.type,
+    id: resource
+  }, (lockErr, lockRes, statusCode) => {
+    if (statusCode === 404) {
+      return cb(null, false);
     }
 
-    this.esClient = settings.esClient;
-    this.index = settings.index;
-    this.type = settings.type || defaultType;
-    this.owner = settings.owner;
-  }
+    cb(lockErr, true, _.get(lockRes, '_source.owner'));
+  });
+};
 
-  acquire(resource, cb) {
-    verifyParameters(resource, cb);
-    this._acquireLock(resource, cb);
-  }
+Lock.prototype.list = function (cb) {
+  this.esClient.search({
+    index: this.index,
+    type: this.type
+  }, (lockErr, locksRes, statusCode) => {
+    if (statusCode === 404) {
+      return cb(null, false);
+    }
 
-  release(resource, cb) {
-    verifyParameters(resource, cb);
-    this._releaseLock(resource, cb);
-  }
+    cb(lockErr, _.reduce(_.get(locksRes, 'hits.hits'), (locks, lockDocument) => {
+      locks[lockDocument._id] = lockDocument._source;
+      return locks;
+    }, {}));
+  });
+};
 
-  isLocked(resource, cb) {
-    this.esClient.get({
-      index: this.index,
-      type: this.type,
-      id: resource
-    }, (lockErr, lockRes, statusCode) => {
-      if (statusCode === 404) {
-        return cb(null, false);
-      }
+Lock.prototype.delete = function (cb) {
+  this.esClient.indices.delete({
+    index: this.index
+  }, (deleteError) => {
+    cb(deleteError);
+  });
+};
 
-      cb(lockErr, true, _.get(lockRes, '_source.owner'));
-    });
-  }
+// 'Private' methods
+Lock.prototype._acquireLock = function (resource, cb) {
+  const lockDocument = {
+    body: {
+      owner: this.owner
+    },
+    index: this.index,
+    type: this.type,
+    id: resource,
+    refresh: true
+  };
 
-  list(cb) {
-    this.esClient.search({
-      index: this.index,
-      type: this.type
-    }, (lockErr, locksRes, statusCode) => {
-      if (statusCode === 404) {
-        return cb(null, false);
-      }
+  this.esClient.create(lockDocument, (err, res) => {
+    // Lock (document) already exists
+    if (err && err.status === 409) {
+      return cb(null, false);
+    }
 
-      cb(lockErr, _.reduce(_.get(locksRes, 'hits.hits'), (locks, lockDocument) => {
-        locks[lockDocument._id] = lockDocument._source;
-        return locks;
-      }, {}));
-    });
-  }
+    cb(err, res && res.created);
+  });
+};
 
-  delete(cb) {
-    this.esClient.indices.delete({
-      index: this.index
-    }, (deleteError) => {
-      cb(deleteError);
-    });
-  }
-
-  // 'Private' methods
-  _acquireLock(resource, cb) {
-    const lockDocument = {
-      body: {
-        owner: this.owner
-      },
-      index: this.index,
-      type: this.type,
-      id: resource,
-      refresh: true
-    };
-
-    this.esClient.create(lockDocument, (err, res) => {
-      // Lock (document) already exists
-      if (err && err.status === 409) {
-        return cb(null, false);
-      }
-
-      cb(err, res && res.created);
-    });
-  }
-
-  _releaseLock(resource, cb) {
-    this.esClient.delete({
-      index: this.index,
-      type: this.type,
-      id: resource,
-      refresh: true
-    }, (deleteError, response) => {
-      cb(deleteError || (response.found ? null : new Error('Missing lockdocument for resource', resource)));
-    });
-  }
-}
+Lock.prototype._releaseLock = function (resource, cb) {
+  this.esClient.delete({
+    index: this.index,
+    type: this.type,
+    id: resource,
+    refresh: true
+  }, (deleteError, response) => {
+    cb(deleteError || (response.found ? null : new Error('Missing lockdocument for resource', resource)));
+  });
+};
 
 module.exports = Lock;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-lock",
   "description": "Lock functionality used within Enrise projects and module's",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/test/lock.spec.js
+++ b/test/lock.spec.js
@@ -35,6 +35,16 @@ describe('Lock', () => {
     expect(newLock.type).to.equal('lockdocument');
   });
 
+
+  it('instantiates without keyword new', () => {
+    const newLock = Lock({ // eslint-disable-line new-cap
+      esClient: esClientStub,
+      owner: 'unittest',
+      index: 'lock-index'
+    });
+    expect(newLock.type).to.equal('lockdocument');
+  });
+
   it('throws an error if owner is invalid or not specified', () => {
     expect(() => {
       new Lock({ // eslint-disable-line no-new


### PR DESCRIPTION
### Context
Enable the lock module to instantiate without keyword `new`

### What has been changed
- Use prototype instead of class definition.
- Update package version.
- Update tests