### PR TITLE
Make sure all methods on instance are bound to current instance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ function Lock(settings) {
   this.index = settings.index;
   this.type = settings.type || defaultType;
   this.owner = settings.owner;
+
+  _.bindAll(this, _.keys(Lock.prototype));
 }
 
 Lock.prototype.acquire = function (resource, cb) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-lock",
   "description": "Lock functionality used within Enrise projects and module's",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/test/lock.spec.js
+++ b/test/lock.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const chai = require('chai');
 const sinon = require('sinon');
 const expect = chai.expect;
@@ -59,6 +60,30 @@ describe('Lock', () => {
         owner: ''
       });
     }).to.throw(Error);
+  });
+
+  it('binds all methods to the current scope', () => {
+    const bindAll = _.bindAll;
+    _.bindAll = sinon.stub();
+
+    const newLock = new Lock({
+      esClient: esClientStub,
+      index: 'lock-index',
+      type: 'lock-type',
+      owner: 'unittest'
+    });
+
+    expect(_.bindAll).to.have.been.calledWith(newLock, [
+      'acquire',
+      'release',
+      'isLocked',
+      'list',
+      'delete',
+      '_acquireLock',
+      '_releaseLock'
+    ]);
+
+    _.bindAll = bindAll;
   });
 
   describe('acquire and release functionality', () => {


### PR DESCRIPTION
### Context
No longer require `lock.bind(lock, ...)` when using async or other libraries that use `apply` or `call` to invoke the instance functions.

### What has been done
- Use bindAll to automatically bind all methods to current scope
- Update patch version